### PR TITLE
Update to newer CMake version, use find_package for Iconv

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@
 # GUTILS_TOOLS:BOOL     if true to enable compilation of gutils tools
 # GUTILS_TEST:BOOL      if true some debug/test classes will be compiled
 
-cmake_minimum_required(VERSION 3.7)
+cmake_minimum_required(VERSION 3.11)
 
 set(Genieutils_LIBRARY genieutils)
 
@@ -16,7 +16,7 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${PROJECT_SOURCE_DIR}/cmake/)
 #set(Boost_USE_STATIC_RUNTIME     ON)
 set(Boost_USE_MULTITHREADED      ON)
 
-find_library(iconv REQUIRED)
+find_package(Iconv REQUIRED)
 
 # dependencies:
 


### PR DESCRIPTION
https://cmake.org/cmake/help/v3.11/module/FindIconv.html

Circumvents build problems with never Linux distributions as Iconv is now part of `libc6-dev`.
This package sets ` Iconv_IS_BUILT_IN` in this case and let CMake continue the configuration process.