### PR TITLE
Fix doubled find_package due to PR#3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,8 +16,6 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${PROJECT_SOURCE_DIR}/cmake/)
 #set(Boost_USE_STATIC_RUNTIME     ON)
 set(Boost_USE_MULTITHREADED      ON)
 
-find_package(Iconv REQUIRED)
-
 # dependencies:
 
 find_package(ZLIB REQUIRED)
@@ -32,7 +30,7 @@ if (GUTILS_TEST)
   find_package(SFML COMPONENTS SYSTEM WINDOW GRAPHICS REQUIRED)
 endif (GUTILS_TEST)
 
-find_package(Iconv)
+find_package(Iconv REQUIRED)
 
 if (${ICONV_FOUND})
   message(STATUS "Iconv found! Language file support: ENABLED")


### PR DESCRIPTION
https://github.com/Tapsa/genieutils/pull/3#issuecomment-770040312

Probably didn't read, but if we do it like this, we don't need to do it twice. So I removed the upper find_package.

Wanted to discuss this in the other PR, but now it's merged already, so this is a follow-up. :) 

superseded by #5 