### PR TITLE
Restore Linux compatibility

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,7 @@ set(Boost_USE_MULTITHREADED      ON)
 # dependencies:
 
 find_package(ZLIB REQUIRED)
+find_package(LZ4 REQUIRED)
 find_package(Boost 1.55 COMPONENTS iostreams REQUIRED)
 
 if(GUTILS_TOOLS)
@@ -169,7 +170,7 @@ if(STATIC_COMPILE)
 else()
   add_library(${Genieutils_LIBRARY} SHARED ${FILE_SRC} ${LANG_SRC} ${DAT_SRC} 
                                     ${RESOURCE_SRC} ${UTIL_SRC} ${SCRIPT_SRC} )
-  target_link_libraries(${Genieutils_LIBRARY} ${ZLIB_LIBRARIES} ${Boost_LIBRARIES} ${ICONV_LIBRARIES})
+  target_link_libraries(${Genieutils_LIBRARY} ${ZLIB_LIBRARIES} ${LZ4_LIBRARIES} ${Boost_LIBRARIES} ${ICONV_LIBRARIES})
 endif(STATIC_COMPILE)
 
 #add_executable(main main.cpp)

--- a/cmake/FindLZ4.cmake
+++ b/cmake/FindLZ4.cmake
@@ -1,0 +1,13 @@
+# - Find lz4
+# Find the native lz4 headers and libraries
+#
+# LZ4_FOUND - True if lz4 was found, false otherwise
+# LZ4_INCLUDE_DIR - where to find the header file lz4.h etc.
+# LZ4_LIBRARIES - List of libraries when using lz4
+
+find_path(LZ4_INCLUDE_DIR NAMES lz4.h)
+
+find_library(LZ4_LIBRARIES NAMES lz4)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(LZ4 DEFAULT_MSG LZ4_LIBRARIES LZ4_INCLUDE_DIR)

--- a/src/lang/LangFile.cpp
+++ b/src/lang/LangFile.cpp
@@ -335,10 +335,10 @@ std::string LangFile::convert(iconv_t cd, std::string input)
   input.copy(inbuf, inleft);
   
   while (cd != (iconv_t)-1 && inleft > 0 && iconv_value == 0)
-  { 
-    iconv_value = iconv(cd, const_cast<const char**>(&inptr), &inleft, &outptr, &outleft);
-    
-    if (iconv_value == (size_t)-1) 
+  {
+    iconv_value = iconv(cd, &inptr, &inleft, &outptr, &outleft);
+
+    if (iconv_value == (size_t)-1)
     {
       if(errno == E2BIG)
       {

--- a/src/util/Logger.cpp
+++ b/src/util/Logger.cpp
@@ -89,7 +89,7 @@ void Logger::log(Logger::LogLevel loglevel, va_list args, const char *msg)
   assert(loglevel >= Logger::LOG_LEVEL);
 
   char msgBuf[1024]; //TODO: reserve memory on time
-  vsprintf_s(msgBuf, 1024, msg, args);
+  vsnprintf(msgBuf, 1024, msg, args);
 
   if (out_)
     *out_ << getLogLevelName(loglevel) << ": " << msgBuf << std::endl;


### PR DESCRIPTION
I was trying to update my tools to work with the latest dat file format and ran into some issues.

I was able to solve them by applying the following changes, which are contained in this pull request:

- Remove invalid conversion from ‘const char**’ to ‘char**’
- Add LZ4 to CMakeLists.txt
- Use vsnprintf for logging instead of vsprintf_s, which is only available on Windows (at least that's what my research yielded)